### PR TITLE
Fix background class names

### DIFF
--- a/src/components/ui/skiper-marquee.tsx
+++ b/src/components/ui/skiper-marquee.tsx
@@ -201,9 +201,9 @@ export function SkiperMarquee() {
               ))}
             </Marquee>
             <div className="absolute ">
-              <div className="bg-backtround absolute inset-0 -z-10  rounded-full opacity-40 blur-xl dark:bg-background" />
+            <div className="bg-background absolute inset-0 -z-10  rounded-full opacity-40 blur-xl dark:bg-background" />
             </div>
-            <div className="to-backtround absolute inset-x-0 bottom-0 h-full bg-gradient-to-b from-transparent to-70% dark:to-background" />
+            <div className="to-background absolute inset-x-0 bottom-0 h-full bg-gradient-to-b from-transparent to-70% dark:to-background" />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- fix typos `bg-backtround` and `to-backtround` in SkiperMarquee component

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479b3e7794832da221b6102c1aff5d